### PR TITLE
Fix typo in include preventing plugins from requiring cp

### DIFF
--- a/scripting/include/chat-processor.inc
+++ b/scripting/include/chat-processor.inc
@@ -67,7 +67,7 @@ public __pl_chat_processor_SetNTVOptional()
 }
 #endif
 
-public SharedPlugin _pl_chat_processor =
+public SharedPlugin __pl_chat_processor =
 {
 	name = "chat-processor",
 	file = "chat-processor.smx",


### PR DESCRIPTION
SourceMod searches for `__pl_` structs!