### PR TITLE
Fixed colon color for CS:S.

### DIFF
--- a/configs/chat_processor.cfg
+++ b/configs/chat_processor.cfg
@@ -30,16 +30,16 @@
 	
 	"cstrike"
 	{
-		"Cstrike_Chat_CT_Loc"	"(Counter-Terrorist) {1} : {2}"
-		"Cstrike_Chat_CT"	"(Counter-Terrorist) {1} : {2}"
-		"Cstrike_Chat_T_Loc"	"(Terrorist) {1} : {2}"
-		"Cstrike_Chat_T"	"(Terrorist) {1} : {2}"
-		"Cstrike_Chat_CT_Dead"	"*DEAD*(Counter-Terrorist) {1} : {2}"
-		"Cstrike_Chat_T_Dead"	"*DEAD*(Terrorist) {1} : {2}"
-		"Cstrike_Chat_Spec"	"(Spectator) {1} : {2}"
-		"Cstrike_Chat_All"	"{1} : {2}"
-		"Cstrike_Chat_AllDead"	"*DEAD* {1} : {2}"
-		"Cstrike_Chat_AllSpec"	"*SPEC* {1} : {2}"
+		"Cstrike_Chat_CT_Loc"	"(Counter-Terrorist) {1}{3} : {2}"
+		"Cstrike_Chat_CT"	"(Counter-Terrorist) {1}{3} : {2}"
+		"Cstrike_Chat_T_Loc"	"(Terrorist) {1}{3} : {2}"
+		"Cstrike_Chat_T"	"(Terrorist) {1}{3} : {2}"
+		"Cstrike_Chat_CT_Dead"	"*DEAD*(Counter-Terrorist) {1}{3} : {2}"
+		"Cstrike_Chat_T_Dead"	"*DEAD*(Terrorist) {1}{3} : {2}"
+		"Cstrike_Chat_Spec"	"(Spectator) {1}{3} : {2}"
+		"Cstrike_Chat_All"	"{1}{3} : {2}"
+		"Cstrike_Chat_AllDead"	"*DEAD* {1}{3} : {2}"
+		"Cstrike_Chat_AllSpec"	"*SPEC* {1}{3} : {2}"
 	}
 	
 	"l4d"

--- a/scripting/chat-processor.sp
+++ b/scripting/chat-processor.sp
@@ -385,6 +385,7 @@ public void Frame_OnChatMessage_SayText2(any data)
 	//Replace the specific characters for the name and message strings.
 	ReplaceString(sBuffer, sizeof(sBuffer), "{1}", sName);
 	ReplaceString(sBuffer, sizeof(sBuffer), "{2}", sMessage);
+	ReplaceString(sBuffer, sizeof(sBuffer), "{3}", "\x01");
 
 	//Process colors based on the final results we have.
 	if (iResults == Plugin_Changed && bProcessColors)


### PR DESCRIPTION
In CS:S (possibly other games too - but I don't play them),
the colon in chat messages has the default chat color.

I've added {3} as a default chat color in the chat-processor.cfg file.